### PR TITLE
Fix ReferenceError for onEndGame in VotingDebugPanel

### DIFF
--- a/src/components/game/VotingDebugPanel.tsx
+++ b/src/components/game/VotingDebugPanel.tsx
@@ -28,11 +28,17 @@ export const VotingDebugPanel: React.FC<VotingDebugPanelProps> = ({
   onGoToFinal3Vote,
   onContinueFromElimination,
   onToggleDebug,
+  // Include optional handlers so they are in scope when used below
+  onSubmitPlayerVote,
+  onSubmitFinal3Vote,
+  onTieBreakResult,
+  onEndGame,
 }) => {
   if (!gameState.debugMode) return null;
 
   const active = gameState.contestants.filter(c => !c.isEliminated);
   const eliminated = gameState.contestants.filter(c => c.isEliminated);
+  const nonPlayerActive = active.filter(c => c.name !== gameState.playerName);
 
   return (
     <div className="fixed bottom-4 right-4 z-50 w-[340px]">


### PR DESCRIPTION
This pull request addresses the ReferenceError: onEndGame is not defined, which occurred during the rendering of the VotingDebugPanel component. I have included optional handlers for onSubmitPlayerVote, onSubmitFinal3Vote, onTieBreakResult, and onEndGame in the component's props to ensure they are available in scope during rendering. This change improves the debug functionality of the game and resolves the rendering issue.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/4n34hp8nudz9](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/4n34hp8nudz9)
Author: Evan Lewis
