### PR TITLE
Fix Jury Vote Logic for Eliminated Players in Finale

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -134,12 +134,15 @@ const Index = () => {
         );
       
       case 'finale':
+        // If the player is eliminated and watching as a juror, continue to the juror-specific jury vote flow.
+        // Otherwise, proceed to the standard jury vote where the player is a finalist.
+        const onFinaleContinue = gameState.isPlayerEliminated ? proceedToJuryVoteAsJuror : proceedToJuryVote;
         return (
           <FinaleEpisode
             gameState={gameState}
             onSubmitSpeech={submitFinaleSpeech}
             onAFPVote={submitAFPVote}
-            onContinue={proceedToJuryVote}
+            onContinue={onFinaleContinue}
           />
         );
       


### PR DESCRIPTION
This PR addresses an issue where the player was incorrectly added to the final 2 during the jury vote process when they should have been treated as a juror. The logic now checks if the player is eliminated and directs them to the appropriate jury vote flow. The function `onContinue` is updated to use `onFinaleContinue`, which correctly routes the player based on their status. This ensures the jury reflects the correct number of finalists and fixes the issue of the view failing to render.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/crmhb51xepoi](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/crmhb51xepoi)
Author: Evan Lewis
