### PR TITLE
Fix Undefined Player Vote Display in Finale

### DIFF
--- a/src/components/game/CharacterCreation.tsx
+++ b/src/components/game/CharacterCreation.tsx
@@ -1,0 +1,217 @@
+import { useMemo, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/enhanced-button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { BACKGROUND_META, PRESET_BACKGROUNDS } from '@/data/backgrounds';
+import { CharacterStats, Contestant, Background, SpecialBackground, StatInclination } from '@/types/game';
+
+interface CharacterCreationProps {
+  onCreate: (player: Contestant) => void;
+}
+
+const STAT_OPTIONS: { key: StatInclination; label: string; hint: string }[] = [
+  { key: 'social', label: 'Social', hint: 'Excel in relationships and persuasion' },
+  { key: 'strategy', label: 'Strategy', hint: 'Excel in planning and reading the game' },
+  { key: 'physical', label: 'Physical', hint: 'Excel in competitions and endurance' },
+  { key: 'deception', label: 'Deception', hint: 'Excel in lies, misdirection, and bluffing' },
+];
+
+export function CharacterCreation({ onCreate }: CharacterCreationProps) {
+  const [name, setName] = useState('');
+  const [age, setAge] = useState<number | ''>('');
+  const [background, setBackground] = useState<Background>('College Athlete');
+  const [customBackgroundText, setCustomBackgroundText] = useState('');
+  const [inclination, setInclination] = useState<StatInclination>('social');
+  const [specialKind, setSpecialKind] = useState<'none' | 'hosts_estranged_child' | 'planted_houseguest'>('none');
+
+  const statBase = useMemo<CharacterStats>(() => {
+    const base = { social: 50, strategy: 50, physical: 50, deception: 50, primary: inclination };
+    base[inclination] += 20;
+    return base;
+  }, [inclination]);
+
+  const statBiased = useMemo<CharacterStats>(() => {
+    const meta = BACKGROUND_META.find(m => m.name === background);
+    const next = { ...statBase };
+    if (meta?.statBias) {
+      Object.entries(meta.statBias).forEach(([key, boost]) => {
+        const k = key as keyof CharacterStats;
+        next[k] = Math.max(20, Math.min(95, (next[k] || 50) + (boost || 0)));
+      });
+    }
+    return next;
+  }, [statBase, background]);
+
+  const personaHint = useMemo(() => {
+    const meta = BACKGROUND_META.find(m => m.name === background);
+    return meta?.personaHint || 'Custom background';
+  }, [background]);
+
+  const special: SpecialBackground = useMemo(() => {
+    if (specialKind === 'none') return { kind: 'none' };
+    if (specialKind === 'hosts_estranged_child') {
+      return { kind: 'hosts_estranged_child', revealed: false };
+    }
+    return {
+      kind: 'planted_houseguest',
+      tasks: [
+        { id: 'p1', description: 'Secretly influence the weekly target', dayAssigned: 2 },
+        { id: 'p2', description: 'Plant a misleading rumor in a group setting', dayAssigned: 5 },
+      ],
+      secretRevealed: false,
+    };
+  }, [specialKind]);
+
+  const canSubmit = name.trim().length >= 2 && typeof age === 'number' && age >= 18 && age <= 65;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    const id = `player_${name.toLowerCase().replace(/\\s+/g, '_')}`;
+    const persona =
+      statBiased.strategy >= statBiased.social && statBiased.strategy >= statBiased.physical && statBiased.strategy >= statBiased.deception
+        ? 'Strategic Player'
+        : statBiased.social >= statBiased.physical && statBiased.social >= statBiased.deception
+        ? 'Social Butterfly'
+        : statBiased.physical >= statBiased.deception
+        ? 'Competitor'
+        : 'Wildcard';
+
+    const player: Contestant = {
+      id,
+      name,
+      age,
+      background,
+      customBackgroundText: background === 'Other' ? customBackgroundText : undefined,
+      stats: statBiased,
+      special,
+      publicPersona: persona,
+      psychProfile: {
+        disposition: ['neutral'],
+        trustLevel: 60,
+        suspicionLevel: 25,
+        emotionalCloseness: 30,
+        editBias: 0,
+      },
+      memory: [],
+      isEliminated: false,
+    };
+
+    onCreate(player);
+  };
+
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-3xl mx-auto">
+        <Card className="p-6 space-y-6">
+          <div>
+            <h1 className="text-3xl font-light">Create Your Character</h1>
+            <p className="text-muted-foreground">Simple setup: choose a background and where you excel.</p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Name</label>
+              <Input value={name} onChange={e => setName(e.target.value)} placeholder="Your name" />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Age</label>
+              <Input
+                type="number"
+                min={18}
+                max={65}
+                value={age}
+                onChange={e => setAge(e.target.value === '' ? '' : Number(e.target.value))}
+                placeholder="Age (18-65)"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Preset Background</label>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {PRESET_BACKGROUNDS.map(bg => (
+                <Button
+                  key={bg}
+                  variant={bg === background ? 'action' : 'surveillance'}
+                  onClick={() => setBackground(bg as Background)}
+                >
+                  {bg}
+                </Button>
+              ))}
+            </div>
+            <div className="text-xs text-muted-foreground">Persona hint: {personaHint}</div>
+            {background === 'Other' && (
+              <div className="mt-2">
+                <Textarea
+                  value={customBackgroundText}
+                  onChange={e => setCustomBackgroundText(e.target.value)}
+                  placeholder="Describe your background"
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Stat Inclination</label>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {STAT_OPTIONS.map(opt => (
+                <Button
+                  key={opt.key}
+                  variant={inclination === opt.key ? 'action' : 'surveillance'}
+                  onClick={() => setInclination(opt.key)}
+                  className="h-auto py-3"
+                >
+                  <div>
+                    <div className="font-medium">{opt.label}</div>
+                    <div className="text-xs text-muted-foreground">{opt.hint}</div>
+                  </div>
+                </Button>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs text-muted-foreground">
+              <div>Social: {statBiased.social}</div>
+              <div>Strategy: {statBiased.strategy}</div>
+              <div>Physical: {statBiased.physical}</div>
+              <div>Deception: {statBiased.deception}</div>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Special Background (Twist)</label>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+              <Button variant={specialKind === 'none' ? 'action' : 'surveillance'} onClick={() => setSpecialKind('none')}>
+                None
+              </Button>
+              <Button
+                variant={specialKind === 'hosts_estranged_child' ? 'action' : 'surveillance'}
+                onClick={() => setSpecialKind('hosts_estranged_child')}
+              >
+                Host's Estranged Child
+              </Button>
+              <Button
+                variant={specialKind === 'planted_houseguest' ? 'action' : 'surveillance'}
+                onClick={() => setSpecialKind('planted_houseguest')}
+              >
+                Planted Houseguest
+              </Button>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {specialKind === 'none' && 'Play a normal game without a hidden twist.'}
+              {specialKind === 'hosts_estranged_child' &&
+                'Secret relation to host. Risky if exposed; can sway edit and house dynamics.'}
+              {specialKind === 'planted_houseguest' &&
+                'Receive tasks from production. Failure risks your secret being revealed.'}
+            </div>
+          </div>
+
+          <Button variant="action" size="wide" disabled={!canSubmit} onClick={handleSubmit}>
+            Start Season
+          </Button>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/ContestantGrid.tsx
+++ b/src/components/game/ContestantGrid.tsx
@@ -4,6 +4,7 @@ import { Progress } from '@/components/ui/progress';
 import { Contestant } from '@/types/game';
 import { Heart, Shield, Eye, Zap, AlertTriangle, Star } from 'lucide-react';
 import { memoryEngine } from '@/utils/memoryEngine';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 interface ContestantGridProps {
   contestants: Contestant[];
@@ -149,20 +150,36 @@ export const ContestantGrid = ({ contestants, playerName }: ContestantGridProps)
                     ))}
                     {/* Stat inclination badge (separate from weekly edit persona) */}
                     {contestant.stats?.primary && (
-                      <Badge variant="secondary" className="text-[10px] ml-1">
-                        <Star className="w-3 h-3 mr-1" />
-                        {contestant.stats.primary}
-                      </Badge>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="secondary" className="text-[10px] ml-1 cursor-help">
+                            <Star className="w-3 h-3 mr-1" />
+                            {contestant.stats.primary}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          Primary stat inclination — influences subtle gameplay outcomes
+                        </TooltipContent>
+                      </Tooltip>
                     )}
-                    {/* Special background badge */}
+                    {/* Special background badge with tooltips */}
                     {contestant.special && contestant.special.kind !== 'none' && (
-                      <Badge
-                        variant={contestant.name === playerName ? 'secondary' : 'outline'}
-                        className="text-[10px] ml-1"
-                      >
-                        {contestant.special.kind === 'hosts_estranged_child' && 'Host’s Child'}
-                        {contestant.special.kind === 'planted_houseguest' && 'Planted HG'}
-                      </Badge>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge
+                            variant={contestant.name === playerName ? 'secondary' : 'outline'}
+                            className="text-[10px] ml-1 cursor-help"
+                          >
+                            {contestant.special.kind === 'hosts_estranged_child' && 'Host’s Child'}
+                            {contestant.special.kind === 'planted_houseguest' && 'Planted HG'}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {contestant.special.kind === 'hosts_estranged_child'
+                            ? 'Secret relation to host. If revealed, trust shifts and edit bias rises.'
+                            : 'Receives production tasks. Failing tasks risks secret reveal.'}
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                   </div>
                 </div>

--- a/src/components/game/ContestantGrid.tsx
+++ b/src/components/game/ContestantGrid.tsx
@@ -2,7 +2,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Contestant } from '@/types/game';
-import { Heart, Shield, Eye, Zap, AlertTriangle } from 'lucide-react';
+import { Heart, Shield, Eye, Zap, AlertTriangle, Star } from 'lucide-react';
 import { memoryEngine } from '@/utils/memoryEngine';
 
 interface ContestantGridProps {
@@ -144,6 +144,20 @@ export const ContestantGrid = ({ contestants, playerName }: ContestantGridProps)
                         {trait}
                       </Badge>
                     ))}
+                    {/* Stat inclination badge (separate from weekly edit persona) */}
+                    {contestant.stats?.primary && (
+                      <Badge variant="secondary" className="text-[10px] ml-1">
+                        <Star className="w-3 h-3 mr-1" />
+                        {contestant.stats.primary}
+                      </Badge>
+                    )}
+                    {/* Special background badge */}
+                    {contestant.special && contestant.special.kind !== 'none' && (
+                      <Badge variant="outline" className="text-[10px] ml-1">
+                        {contestant.special.kind === 'hosts_estranged_child' && 'Host’s Child'}
+                        {contestant.special.kind === 'planted_houseguest' && 'Planted HG'}
+                      </Badge>
+                    )}
                   </div>
                 </div>
               </Card>

--- a/src/components/game/ContestantGrid.tsx
+++ b/src/components/game/ContestantGrid.tsx
@@ -72,7 +72,10 @@ export const ContestantGrid = ({ contestants, playerName }: ContestantGridProps)
                   {/* Header with name and status indicators */}
                   <div className="flex items-center justify-between">
                     <div>
-                      <h4 className="font-medium text-sm">{contestant.name}</h4>
+                      <h4 className="font-medium text-sm">
+                        {contestant.name}
+                        {contestant.name === playerName ? ' (You)' : ''}
+                      </h4>
                       <p className="text-xs text-muted-foreground">{contestant.publicPersona}</p>
                     </div>
                     <div className="flex items-center gap-1">
@@ -153,7 +156,10 @@ export const ContestantGrid = ({ contestants, playerName }: ContestantGridProps)
                     )}
                     {/* Special background badge */}
                     {contestant.special && contestant.special.kind !== 'none' && (
-                      <Badge variant="outline" className="text-[10px] ml-1">
+                      <Badge
+                        variant={contestant.name === playerName ? 'secondary' : 'outline'}
+                        className="text-[10px] ml-1"
+                      >
                         {contestant.special.kind === 'hosts_estranged_child' && 'Host’s Child'}
                         {contestant.special.kind === 'planted_houseguest' && 'Planted HG'}
                       </Badge>

--- a/src/components/game/DashboardHeader.tsx
+++ b/src/components/game/DashboardHeader.tsx
@@ -1,7 +1,8 @@
+import { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Users, Shield, Crown, Timer } from 'lucide-react';
+import { Users, Shield, Crown, Timer, Star } from 'lucide-react';
 import { GameState } from '@/types/game';
 
 interface DashboardHeaderProps {
@@ -12,9 +13,10 @@ interface DashboardHeaderProps {
   onTitle?: () => void;
   onToggleDebug?: () => void;
   hasSave?: boolean;
+  onOpenRoster?: () => void;
 }
 
-export const DashboardHeader = ({ gameState, onSave, onLoad, onDeleteSave, onTitle, onToggleDebug, hasSave }: DashboardHeaderProps) => {
+export const DashboardHeader = ({ gameState, onSave, onLoad, onDeleteSave, onTitle, onToggleDebug, hasSave, onOpenRoster }: DashboardHeaderProps) => {
   const activeContestants = gameState.contestants.filter(c => !c.isEliminated);
   const remainingCount = activeContestants.length;
   
@@ -34,6 +36,24 @@ export const DashboardHeader = ({ gameState, onSave, onLoad, onDeleteSave, onTit
     if (weeksUntilJury <= 2) return "Pre-Jury Finale";
     return "Pre-Jury";
   };
+
+  // Roster quick access toggle, persisted
+  const [rosterPinned, setRosterPinned] = useState<boolean>(false);
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('rtv_roster_button_pinned');
+      setRosterPinned(raw ? JSON.parse(raw) : false);
+    } catch {}
+  }, []);
+  const toggleRosterPinned = () => {
+    const next = !rosterPinned;
+    setRosterPinned(next);
+    try {
+      localStorage.setItem('rtv_roster_button_pinned', JSON.stringify(next));
+    } catch {}
+  };
+
+  const showRosterButton = gameState.gamePhase === 'premiere' || rosterPinned;
 
   return (
     <div className="bg-background/90 backdrop-blur-md border-b border-border/60 sticky top-0 z-50">
@@ -88,6 +108,27 @@ export const DashboardHeader = ({ gameState, onSave, onLoad, onDeleteSave, onTit
                   <Shield className="w-3 h-3" />
                   {gameState.immunityWinner} has immunity
                 </Badge>
+              )}
+
+              {/* Roster quick access */}
+              {showRosterButton && (
+                <div className="flex items-center gap-1">
+                  <Button variant="secondary" size="sm" onClick={onOpenRoster} aria-label="Meet the Houseguests">
+                    <Users className="w-4 h-4 mr-1" />
+                    Roster
+                  </Button>
+                  <Button
+                    variant={rosterPinned ? 'secondary' : 'outline'}
+                    size="icon"
+                    onClick={toggleRosterPinned}
+                    aria-pressed={rosterPinned}
+                    aria-label="Pin roster button"
+                    className="h-8 w-8"
+                    title="Pin roster button"
+                  >
+                    <Star className="w-4 h-4" />
+                  </Button>
+                </div>
               )}
             </div>
           </div>

--- a/src/components/game/EnhancedInformationPanel.tsx
+++ b/src/components/game/EnhancedInformationPanel.tsx
@@ -1,8 +1,9 @@
 import { Card } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/enhanced-button';
 import { GameState } from '@/types/game';
-import { Clock, Users, AlertCircle } from 'lucide-react';
+import { Clock, Users, AlertCircle, Star, Flame } from 'lucide-react';
 
 interface EnhancedInformationPanelProps {
   gameState: GameState;
@@ -42,6 +43,18 @@ export const EnhancedInformationPanel = ({ gameState }: EnhancedInformationPanel
       info: `${contestant.name} may be targeting you - high suspicion levels detected`,
       day: gameState.currentDay,
       type: 'threat'
+    }));
+
+  const player = gameState.contestants.find(c => c.name === gameState.playerName);
+  const isPlanted = player?.special && player.special.kind === 'planted_houseguest';
+
+  const castQuickStats = gameState.contestants
+    .filter(c => !c.isEliminated)
+    .slice(0, 4)
+    .map(c => ({
+      name: c.name,
+      primary: c.stats?.primary,
+      special: c.special?.kind,
     }));
 
   return (
@@ -99,6 +112,85 @@ export const EnhancedInformationPanel = ({ gameState }: EnhancedInformationPanel
               {relationshipInsights.map((insight, index) => (
                 <div key={index} className="text-xs text-foreground border-l-2 border-edit-darkhorse pl-2">
                   <span>{insight.info}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Cast Quick Stats (separate from weekly edit persona) */}
+          {castQuickStats.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Star className="w-3 h-3 text-primary" />
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Cast Quick Stats
+                </span>
+              </div>
+              {castQuickStats.map((c) => (
+                <div key={c.name} className="text-xs text-foreground border-l-2 border-primary pl-2 flex items-center justify-between">
+                  <span>{c.name}</span>
+                  <div className="flex items-center gap-2">
+                    {c.primary && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        <Star className="w-3 h-3 mr-1" />
+                        {c.primary}
+                      </Badge>
+                    )}
+                    {c.special && c.special !== 'none' && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {c.special === 'hosts_estranged_child' ? 'Host’s Child' : 'Planted HG'}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Planted Houseguest Task Panel (if applicable) */}
+          {isPlanted && (
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Flame className="w-3 h-3 text-primary" />
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Production Tasks
+                </span>
+              </div>
+              {(player!.special as any).tasks.map((task: any) => (
+                <div key={task.id} className="text-xs text-foreground border-l-2 border-primary pl-2">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="font-medium">{task.description}</div>
+                      <div className="text-[10px] text-muted-foreground">Assigned Day {task.dayAssigned}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Badge variant={task.completed ? 'secondary' : 'outline'} className="text-[10px]">
+                        {task.completed ? 'Completed' : 'Pending'}
+                      </Badge>
+                      {!task.completed && (
+                        <>
+                          <Button
+                            variant="action"
+                            size="sm"
+                            onClick={() => {
+                              window.dispatchEvent(new CustomEvent('plantedTaskUpdate', { detail: { taskId: task.id, completed: true } }));
+                            }}
+                          >
+                            Complete
+                          </Button>
+                          <Button
+                            variant="surveillance"
+                            size="sm"
+                            onClick={() => {
+                              window.dispatchEvent(new CustomEvent('plantedTaskUpdate', { detail: { taskId: task.id, completed: false } }));
+                            }}
+                          >
+                            Fail
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/components/game/Final3VoteScreen.tsx
+++ b/src/components/game/Final3VoteScreen.tsx
@@ -12,7 +12,8 @@ interface Final3VoteScreenProps {
     winner1: string,
     winner2: string,
     method?: 'challenge' | 'fire_making' | 'random_draw',
-    results?: { name: string; time: number }[]
+    results?: { name: string; time: number }[],
+    selectionReason?: 'player_persuasion' | 'npc_choice' | 'manual'
   ) => void;
 }
 

--- a/src/components/game/JuryVoteScreen.tsx
+++ b/src/components/game/JuryVoteScreen.tsx
@@ -116,8 +116,8 @@ export const JuryVoteScreen = ({ gameState, playerSpeech, onGameEnd }: JuryVoteS
     setVotes(juryVotes);
     setRationales(rationaleMap);
 
-    // If the player is not in the jury, all votes are in, mark stable.
-    if (!isPlayerInJury) {
+    // If all jurors except possibly the player have votes, and player isn't in jury, lock votes.
+    if (!isPlayerInJury && Object.keys(juryVotes).length === juryMembers.length) {
       setVoteStable(true);
     }
   }, [finalTwo, juryMembers, gameState.playerName, playerSpeech, voteStable, isPlayerInJury, effectivePlayerSpeech, speechEval.impact, speechEval.tier]);
@@ -147,6 +147,10 @@ export const JuryVoteScreen = ({ gameState, playerSpeech, onGameEnd }: JuryVoteS
   useEffect(() => {
     if (!voteStable || showResults) return;
 
+    // Guard: only proceed if every juror has a defined vote
+    const allJurorsVoted = juryMembers.every(j => Boolean(votes[j.name]));
+    if (!allJurorsVoted) return;
+
     const voteCounts: { [finalist: string]: number } = {};
     finalTwo.forEach(f => (voteCounts[f.name] = 0));
 
@@ -163,7 +167,7 @@ export const JuryVoteScreen = ({ gameState, playerSpeech, onGameEnd }: JuryVoteS
     // Show results after a brief delay for dramatic effect
     const timer = setTimeout(() => setShowResults(true), RESULT_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [voteStable, votes, finalTwo, showResults, RESULT_DELAY_MS]);
+  }, [voteStable, votes, finalTwo, showResults, RESULT_DELAY_MS, juryMembers]);
 
   // Start animated per-juror reveal once results are shown
   useEffect(() => {

--- a/src/components/game/JuryVoteScreen.tsx
+++ b/src/components/game/JuryVoteScreen.tsx
@@ -349,7 +349,11 @@ export const JuryVoteScreen = ({ gameState, playerSpeech, onGameEnd }: JuryVoteS
                             {jury.name}{jury.name === gameState.playerName ? ' (You)' : ''}
                           </span>
                           <span className={`font-medium ${revealed ? 'text-foreground' : 'text-muted-foreground'}`}>
-                            {revealed ? `voted for ${votes[jury.name]}` : 'vote sealed...'}
+                            {revealed
+                              ? (votes[jury.name]
+                                  ? `voted for ${votes[jury.name]}`
+                                  : (jury.name === gameState.playerName ? 'did not vote' : 'vote pending'))
+                              : 'vote sealed...'}
                           </span>
                         </div>
                         {revealed && rationales[jury.name] && (

--- a/src/components/game/MeetHouseguestsScreen.tsx
+++ b/src/components/game/MeetHouseguestsScreen.tsx
@@ -1,0 +1,107 @@
+import { Card } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/enhanced-button';
+import { GameState, Contestant } from '@/types/game';
+import { Users, Star, IdCard, Heart, Flame } from 'lucide-react';
+
+interface MeetHouseguestsScreenProps {
+  gameState: GameState;
+  onContinue: () => void;
+}
+
+export const MeetHouseguestsScreen = ({ gameState, onContinue }: MeetHouseguestsScreenProps) => {
+  const contestants = gameState.contestants;
+
+  const renderContestantCard = (c: Contestant) => {
+    const isPlayer = c.name === gameState.playerName;
+
+    return (
+      <Card key={c.id} className={`p-4 flex flex-col gap-2 ${isPlayer ? 'border-primary/20 bg-primary/10' : ''}`}>
+        <div className="flex items-center justify-between">
+          <div>
+            <div className={`font-medium ${isPlayer ? 'text-primary' : ''}`}>
+              {c.name}{isPlayer ? ' (You)' : ''}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {c.publicPersona}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {c.stats?.primary && (
+              <Badge variant={isPlayer ? 'secondary' : 'outline'} className="text-[10px]">
+                <Star className="w-3 h-3 mr-1" />
+                {c.stats.primary}
+              </Badge>
+            )}
+            {c.special && c.special.kind !== 'none' && (
+              <Badge variant={isPlayer ? 'secondary' : 'outline'} className="text-[10px]">
+                {c.special.kind === 'hosts_estranged_child' && 'Host’s Child'}
+                {c.special.kind === 'planted_houseguest' && 'Planted HG'}
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="text-xs flex items-center gap-2">
+          <IdCard className="w-3 h-3 text-muted-foreground" />
+          <span>
+            {c.age ? `Age ${c.age}` : 'Age unknown'}
+            {c.background ? ` • ${c.background}` : ''}
+          </span>
+        </div>
+
+        {c.customBackgroundText && (
+          <div className="text-xs text-muted-foreground">
+            {c.customBackgroundText}
+          </div>
+        )}
+
+        {c.stats && (
+          <div className="grid grid-cols-2 gap-2 text-[11px] text-foreground pt-1">
+            <div className="flex items-center gap-2">
+              <Heart className="w-3 h-3 text-pink-500" />
+              <span>Social: {c.stats.social}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Star className="w-3 h-3 text-blue-500" />
+              <span>Strategy: {c.stats.strategy}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Flame className="w-3 h-3 text-orange-500" />
+              <span>Physical: {c.stats.physical}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Users className="w-3 h-3 text-green-500" />
+              <span>Deception: {c.stats.deception}</span>
+            </div>
+          </div>
+        )}
+      </Card>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <Card className="p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <Users className="w-6 h-6 text-primary" />
+            <div>
+              <h1 className="text-2xl font-light">Meet the Houseguests</h1>
+              <p className="text-muted-foreground">Premiere night: intros and first impressions</p>
+            </div>
+          </div>
+          <ScrollArea className="h-[520px]">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {contestants.map(renderContestantCard)}
+            </div>
+          </ScrollArea>
+          <Button variant="action" size="wide" className="mt-6" onClick={onContinue}>
+            Begin Week 1
+          </Button>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/PostSeasonRecapScreen.tsx
+++ b/src/components/game/PostSeasonRecapScreen.tsx
@@ -310,7 +310,13 @@ export const PostSeasonRecapScreen = ({ gameState, winner, finalVotes, onRestart
                         <div className={`font-medium ${juror === gameState.playerName ? 'text-primary' : ''}`}>
                           {juror}{juror === gameState.playerName ? ' (You)' : ''}
                         </div>
-                        <div className="text-sm">voted for <span className="font-medium">{vote}</span></div>
+                        <div className="text-sm">
+                          {vote ? (
+                            <>voted for <span className="font-medium">{vote}</span></>
+                          ) : (
+                            <span className="text-muted-foreground">{juror === gameState.playerName ? 'did not vote' : 'vote pending'}</span>
+                          )}
+                        </div>
                       </div>
                       {gameState.juryRationales?.[juror] && (
                         <div className="text-xs text-muted-foreground mt-1">

--- a/src/components/game/PostSeasonRecapScreen.tsx
+++ b/src/components/game/PostSeasonRecapScreen.tsx
@@ -50,12 +50,13 @@ export const PostSeasonRecapScreen = ({ gameState, winner, finalVotes, onRestart
 
         {/* Tabbed Content */}
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-6">
+          <TabsList className="grid w-full grid-cols-7">
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="stats">Statistics</TabsTrigger>
             <TabsTrigger value="timeline">Timeline</TabsTrigger>
             <TabsTrigger value="jury">Jury Votes</TabsTrigger>
             <TabsTrigger value="final3">Final 3 Tie-Break</TabsTrigger>
+            <TabsTrigger value="twists">Twists</TabsTrigger>
             <TabsTrigger value="awards">Awards</TabsTrigger>
           </TabsList>
 
@@ -436,6 +437,73 @@ export const PostSeasonRecapScreen = ({ gameState, winner, finalVotes, onRestart
                       </div>
                     </Card>
                   )}
+                </div>
+              )}
+            </Card>
+          </TabsContent>
+
+          {/* Twists & Special Backgrounds */}
+          <TabsContent value="twists" className="space-y-6">
+            <Card className="p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <Trophy className="w-5 h-5 text-primary" />
+                <h3 className="text-xl font-medium">Twists & Special Backgrounds</h3>
+              </div>
+
+              {/* Host's Estranged Child */}
+              {gameState.hostChildName ? (
+                <div className="p-4 border border-border rounded mb-4">
+                  <div className="font-medium">Host’s Estranged Child</div>
+                  <div className="text-sm text-muted-foreground">
+                    {gameState.hostChildName}{gameState.hostChildName === gameState.playerName ? ' (You)' : ''} had their secret revealed
+                    {typeof gameState.hostChildRevealDay === 'number' ? ` on Day ${gameState.hostChildRevealDay}` : ''}.
+                  </div>
+                </div>
+              ) : (
+                <div className="p-4 border border-border rounded mb-4 text-sm text-muted-foreground">
+                  No host-family twist revealed this season.
+                </div>
+              )}
+
+              {/* Planted Houseguest(s) */}
+              {gameState.contestants.some(c => c.special?.kind === 'planted_houseguest') ? (
+                <div className="space-y-3">
+                  {gameState.contestants
+                    .filter(c => c.special?.kind === 'planted_houseguest')
+                    .map(c => {
+                      const spec = c.special as any;
+                      return (
+                        <div key={c.id} className="p-4 border border-border rounded">
+                          <div className="flex items-center justify-between">
+                            <div className="font-medium">
+                              Planted Houseguest: {c.name}{c.name === gameState.playerName ? ' (You)' : ''}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {spec.secretRevealed
+                                ? `Secret revealed${spec.revealDay ? ` on Day ${spec.revealDay}` : ''}`
+                                : 'Secret remained hidden'}
+                            </div>
+                          </div>
+                          <div className="mt-2 space-y-1">
+                            {(spec.tasks || []).map((t: any) => (
+                              <div key={t.id} className="flex items-center justify-between text-sm">
+                                <div>
+                                  <span className="font-medium">{t.description}</span>
+                                  <span className="text-muted-foreground text-xs"> — Assigned Day {t.dayAssigned}</span>
+                                </div>
+                                <Badge variant={t.completed ? 'secondary' : 'outline'} className="text-[10px]">
+                                  {t.completed ? 'Completed' : 'Pending'}
+                                </Badge>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+              ) : (
+                <div className="p-4 border border-border rounded text-sm text-muted-foreground">
+                  No planted houseguest twist this season.
                 </div>
               )}
             </Card>

--- a/src/components/game/PremiereCutscene.tsx
+++ b/src/components/game/PremiereCutscene.tsx
@@ -1,32 +1,100 @@
 import { Cutscene, CutsceneSlide } from './cutscenes/Cutscene';
+import { GameState } from '@/types/game';
 
 interface PremiereCutsceneProps {
   onComplete: () => void;
+  gameState?: GameState;
 }
 
-export const PremiereCutscene = ({ onComplete }: PremiereCutsceneProps) => {
-  const slides: CutsceneSlide[] = [
-    {
-      title: 'Cold Open',
-      speaker: 'Narrator',
-      text: 'Cameras hum. Doors slide open. A dozen stories cross in one house. The edit will decide which one becomes legend.',
-    },
-    {
+export const PremiereCutscene = ({ onComplete, gameState }: PremiereCutsceneProps) => {
+  const contestants = gameState?.contestants || [];
+  const playerName = gameState?.playerName || 'You';
+
+  // Build Big Brother style intros and first meeting montage
+  const introSlides: CutsceneSlide[] = [];
+
+  introSlides.push({
+    title: 'Cold Open',
+    speaker: 'Narrator',
+    text: 'Cameras hum. Doors slide open. A dozen stories cross in one house. The edit will decide which one becomes legend.',
+  });
+
+  // Player intro
+  const player = contestants.find(c => c.name === playerName);
+  if (player) {
+    introSlides.push({
+      title: 'Your Arrival',
+      speaker: playerName,
+      text:
+        player.background && player.background !== 'Other'
+          ? `${playerName}, ${player.background.toLowerCase()}. Strengths: ${
+              player.stats?.primary || 'social'
+            }. Eyes on the room, hands steady on the story.`
+          : `${playerName}. Strengths: ${player.stats?.primary || 'social'}. Take a breath. Step in.`,
+      aside: player.customBackgroundText ? `Backstory: ${player.customBackgroundText}` : undefined,
+    });
+  } else {
+    introSlides.push({
       title: 'Confessional',
       speaker: 'You',
       text: 'Day one. New faces, new tells. Play quiet. Listen louder. The story starts whether I speak or not.',
-    },
-    {
-      title: 'Host Stinger',
-      speaker: 'Mars Vega (Host)',
-      text: 'Welcome to The Edit. Every conversation is a choice. Every silence is too. Good luck.',
-    },
-    {
-      title: 'House Entry',
-      text: 'Footsteps on polished floor. The room adjusts to you. Time to write the first line of your story.',
-      aside: 'Tip: confessionals shift your screen-time and approval. Use them.',
-    },
-  ];
+    });
+  }
 
-  return <Cutscene title="Premiere Night" slides={slides} onComplete={onComplete} ctaLabel="Enter the House" />;
+  // Quick-fire intros for a subset of NPCs
+  contestants
+    .filter(c => c.name !== playerName)
+    .slice(0, 7)
+    .forEach(c => {
+      const prim = c.stats?.primary || 'social';
+      const special =
+        c.special && c.special.kind !== 'none'
+          ? c.special.kind === 'hosts_estranged_child'
+            ? 'Rumored ties beyond the walls.'
+            : 'Production plants curious seeds.'
+          : undefined;
+
+      introSlides.push({
+        title: 'Arrival',
+        speaker: c.name,
+        text:
+          c.background && c.background !== 'Other'
+            ? `${c.name}, ${c.background.toLowerCase()}. Leans ${prim}. ${c.publicPersona}.`
+            : `${c.name}. Leans ${prim}. ${c.publicPersona}.`,
+        aside: special,
+      });
+    });
+
+  // First meeting montage
+  introSlides.push({
+    title: 'The Meeting',
+    text:
+      'Helloes overlap. Hugs, handshakes, glances. Names travel fast; judgments travel faster. The house calibrates social gravity.',
+    aside: 'Tip: Observe early. First impressions harden into habits.',
+  });
+
+  // Host welcome
+  introSlides.push({
+    title: 'Host Stinger',
+    speaker: 'Mars Vega (Host)',
+    text:
+      'Welcome to The Edit. Every conversation is a choice. Every silence is too. Your first week starts now—good luck.',
+  });
+
+  // House entry
+  introSlides.push({
+    title: 'House Entry',
+    text:
+      'Footsteps on polished floor. The room adjusts to you. Time to write the first line of your story.',
+    aside: 'Confessionals affect screen-time and approval. Use them.',
+  });
+
+  return (
+    <Cutscene
+      title="Premiere Night"
+      slides={introSlides}
+      onComplete={onComplete}
+      ctaLabel="Enter the House"
+    />
+  );
 };

--- a/src/data/backgrounds.ts
+++ b/src/data/backgrounds.ts
@@ -1,0 +1,89 @@
+export const PRESET_BACKGROUNDS = [
+  'College Athlete',
+  'Startup Founder',
+  'School Teacher',
+  'Bartender',
+  'ER Nurse',
+  'Law Student',
+  'Podcaster',
+  'Ex-Pro Gamer',
+  'Content Creator',
+  'Blue-Collar Worker',
+  'Fitness Trainer',
+  'Real Estate Agent',
+  'Data Analyst',
+  'Musician',
+  'Chef',
+  'Other',
+] as const;
+
+export type PresetBackground = typeof PRESET_BACKGROUNDS[number];
+
+export interface BackgroundPresetMeta {
+  name: PresetBackground;
+  personaHint: string;
+  statBias?: Partial<Record<'social' | 'strategy' | 'physical' | 'deception', number>>;
+}
+
+export const BACKGROUND_META: BackgroundPresetMeta[] = [
+  { name: 'College Athlete', personaHint: 'Competitor with team-first energy', statBias: { physical: 20, social: 5 } },
+  { name: 'Startup Founder', personaHint: 'Strategic and persuasive', statBias: { strategy: 20, social: 10 } },
+  { name: 'School Teacher', personaHint: 'Patient and observant', statBias: { social: 15, strategy: 5 } },
+  { name: 'Bartender', personaHint: 'Social connector who reads the room', statBias: { social: 20, deception: 5 } },
+  { name: 'ER Nurse', personaHint: 'Calm under pressure', statBias: { strategy: 10, physical: 10 } },
+  { name: 'Law Student', personaHint: 'Argumentative and detail-oriented', statBias: { strategy: 15, deception: 10 } },
+  { name: 'Podcaster', personaHint: 'Storyteller with audience awareness', statBias: { social: 15 } },
+  { name: 'Ex-Pro Gamer', personaHint: 'Calm planner, clutch performer', statBias: { strategy: 10, physical: 10 } },
+  { name: 'Content Creator', personaHint: 'Entertaining and performative', statBias: { social: 10, deception: 5 } },
+  { name: 'Blue-Collar Worker', personaHint: 'Hard-working and resilient', statBias: { physical: 10, social: 5 } },
+  { name: 'Fitness Trainer', personaHint: 'Disciplined and competitive', statBias: { physical: 20 } },
+  { name: 'Real Estate Agent', personaHint: 'Negotiator and networker', statBias: { social: 15, strategy: 5 } },
+  { name: 'Data Analyst', personaHint: 'Analytical and composed', statBias: { strategy: 20 } },
+  { name: 'Musician', personaHint: 'Creative and charismatic', statBias: { social: 10 } },
+  { name: 'Chef', personaHint: 'Leader in high-pressure environments', statBias: { physical: 5, strategy: 10 } },
+  { name: 'Other', personaHint: 'Custom background', statBias: {} },
+];
+
+export type SpecialKind = 'none' | 'hosts_estranged_child' | 'planted_houseguest';
+
+export interface SpecialLogicDescription {
+  kind: SpecialKind;
+  summary: string;
+  triggers: string[]; // game events that may affect reveal
+  consequences: string[]; // what happens if revealed or tasks fail
+}
+
+export const SPECIAL_BACKGROUNDS_LOGIC: SpecialLogicDescription[] = [
+  {
+    kind: 'hosts_estranged_child',
+    summary: 'Secret relation to host. If exposed, audience edit swings and house trust shifts.',
+    triggers: [
+      'Rumor event mentions family ties',
+      'Production hint during a twist',
+      'Confessional leak memory referencing host',
+    ],
+    consequences: [
+      'Trust -10 from suspicious players; +10 editBias due to storyline',
+      'If embraced publicly: potential social boost with empathetic players',
+    ],
+  },
+  {
+    kind: 'planted_houseguest',
+    summary: 'Receives production tasks. Failure risks secret reveal.',
+    triggers: [
+      'Weekly task assigned by production',
+      'Task failure two days in a row',
+      'Confessional leak reveals production interference',
+    ],
+    consequences: [
+      'On failure chain: secretRevealed=true; suspicion spikes from strategic players',
+      'On consistent success: subtle editBias boost and influence with chaos-prone NPCs',
+    ],
+  },
+  {
+    kind: 'none',
+    summary: 'No special twist background.',
+    triggers: [],
+    consequences: [],
+  },
+];

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -971,6 +971,13 @@ export const useGameState = () => {
   const completePremiere = useCallback(() => {
     setGameState(prev => ({
       ...prev,
+      gamePhase: 'houseguests_roster' as const
+    }));
+  }, []);
+
+  const completeRoster = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
       gamePhase: 'daily' as const
     }));
   }, []);
@@ -1687,6 +1694,7 @@ export const useGameState = () => {
     respondToForcedConversation,
     submitAFPVote,
     completePremiere,
+    completeRoster,
     endGame,
     continueFromElimination,
     continueFromWeeklyRecap,

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -982,6 +982,13 @@ export const useGameState = () => {
     }));
   }, []);
 
+  const openRoster = useCallback(() => {
+    setGameState(prev => ({
+      ...prev,
+      gamePhase: 'houseguests_roster' as const
+    }));
+  }, []);
+
   // Finalize character creation: build cast and proceed to premiere
   const finalizeCharacterCreation = useCallback((player: Contestant) => {
     setGameState(prev => {
@@ -1695,6 +1702,7 @@ export const useGameState = () => {
     submitAFPVote,
     completePremiere,
     completeRoster,
+    openRoster,
     endGame,
     continueFromElimination,
     continueFromWeeklyRecap,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { WeeklyRecapScreen } from '@/components/game/WeeklyRecapScreen';
 import { ImmunityCompetitionScreen } from '@/components/game/ImmunityCompetitionScreen';
 import { JuryVoteScreen } from '@/components/game/JuryVoteScreen';
 import { PremiereCutscene } from '@/components/game/PremiereCutscene';
+import { CharacterCreation } from '@/components/game/CharacterCreation';
 import { EliminationEpisode } from '@/components/game/EliminationEpisode';
 import { FinaleEpisode } from '@/components/game/FinaleEpisode';
 import { PlayerVoteScreen } from '@/components/game/PlayerVoteScreen';
@@ -46,6 +47,7 @@ const Index = () => {
     deleteSavedGame,
     hasSavedGame,
     goToTitle,
+  finalizeCharacterCreation,
   } = useGameState();
 
   // Keyboard shortcut: Shift+D to toggle debug HUD
@@ -94,8 +96,14 @@ const Index = () => {
             hasSave={hasSavedGame()}
           />
         );
+      case 'character_creation':
+        return (
+          <CharacterCreation
+            onCreate={finalizeCharacterCreation}
+          />
+        );
       case 'premiere':
-        return <PremiereCutscene onComplete={completePremiere} />;
+        return <PremiereCutscene onComplete={completePremiere} gameState={gameState} />;
       
       case 'daily':
         return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,6 +15,7 @@ import { PostSeasonRecapScreen } from '@/components/game/PostSeasonRecapScreen';
 import { VotingDebugPanel } from '@/components/game/VotingDebugPanel';
 import { DashboardHeader } from '@/components/game/DashboardHeader';
 import { ErrorBoundary } from '@/components/game/ErrorBoundary';
+import { MeetHouseguestsScreen } from '@/components/game/MeetHouseguestsScreen';
 
 const Index = () => {
   const {
@@ -34,6 +35,7 @@ const Index = () => {
     resetGame,
     handleEmergentEventChoice,
     completePremiere,
+    completeRoster,
     tagTalk,
     handleTieBreakResult,
     proceedToJuryVote,
@@ -47,7 +49,7 @@ const Index = () => {
     deleteSavedGame,
     hasSavedGame,
     goToTitle,
-  finalizeCharacterCreation,
+    finalizeCharacterCreation,
   } = useGameState();
 
   // Keyboard shortcut: Shift+D to toggle debug HUD
@@ -104,7 +106,13 @@ const Index = () => {
         );
       case 'premiere':
         return <PremiereCutscene onComplete={completePremiere} gameState={gameState} />;
-      
+      case 'houseguests_roster':
+        return (
+          <MeetHouseguestsScreen
+            gameState={gameState}
+            onContinue={completeRoster}
+          />
+        );
       case 'daily':
         return (
            <GameplayScreen

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -36,6 +36,7 @@ const Index = () => {
     handleEmergentEventChoice,
     completePremiere,
     completeRoster,
+    openRoster,
     tagTalk,
     handleTieBreakResult,
     proceedToJuryVote,
@@ -220,6 +221,7 @@ const Index = () => {
           onTitle={goToTitle}
           onToggleDebug={toggleDebugMode}
           hasSave={hasSavedGame()}
+          onOpenRoster={openRoster}
         />
       )}
       {renderScreen()}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,7 +1,56 @@
+export type StatInclination = 'social' | 'strategy' | 'physical' | 'deception';
+
+export interface CharacterStats {
+  // 0..100 scale. Use inclinations to bias NPC calculations and gameplay outcomes.
+  social: number;
+  strategy: number;
+  physical: number;
+  deception: number;
+  // primary inclination to surface in UI
+  primary?: StatInclination;
+}
+
+export type Background =
+  | 'College Athlete'
+  | 'Startup Founder'
+  | 'School Teacher'
+  | 'Bartender'
+  | 'ER Nurse'
+  | 'Law Student'
+  | 'Podcaster'
+  | 'Ex-Pro Gamer'
+  | 'Content Creator'
+  | 'Blue-Collar Worker'
+  | 'Fitness Trainer'
+  | 'Real Estate Agent'
+  | 'Data Analyst'
+  | 'Musician'
+  | 'Chef'
+  | 'Other'; // For custom background text
+
+export type SpecialBackground =
+  | { kind: 'none' }
+  | {
+      kind: 'hosts_estranged_child';
+      // Hidden until revealed. If revealed, affects audience/edit and NPC trust.
+      revealed?: boolean;
+    }
+  | {
+      kind: 'planted_houseguest';
+      // Production tasks to complete weekly. Failure risks secret reveal.
+      tasks: { id: string; description: string; dayAssigned: number; completed?: boolean }[];
+      secretRevealed?: boolean;
+    };
+
 export interface Contestant {
   id: string;
   name: string;
+  age?: number;
   publicPersona: string;
+  background?: Background;
+  customBackgroundText?: string;
+  stats?: CharacterStats;
+  special?: SpecialBackground;
   psychProfile: {
     disposition: string[];
     trustLevel: number; // -100 to 100
@@ -17,7 +66,14 @@ export interface Contestant {
 
 export interface GameMemory {
   day: number;
-  type: 'conversation' | 'scheme' | 'observation' | 'dm' | 'confessional_leak' | 'elimination' | 'event';
+  type:
+    | 'conversation'
+    | 'scheme'
+    | 'observation'
+    | 'dm'
+    | 'confessional_leak'
+    | 'elimination'
+    | 'event';
   participants: string[];
   content: string;
   emotionalImpact: number; // -10 to 10
@@ -37,7 +93,14 @@ export interface InteractionLogEntry {
 }
 
 export interface PlayerAction {
-  type: 'talk' | 'dm' | 'confessional' | 'observe' | 'scheme' | 'activity' | 'alliance_meeting';
+  type:
+    | 'talk'
+    | 'dm'
+    | 'confessional'
+    | 'observe'
+    | 'scheme'
+    | 'activity'
+    | 'alliance_meeting';
   target?: string;
   content?: string;
   tone?: string;
@@ -45,7 +108,13 @@ export interface PlayerAction {
   usageCount?: number;
 }
 
-export type ReactionTake = 'positive' | 'neutral' | 'deflect' | 'pushback' | 'suspicious' | 'curious';
+export type ReactionTake =
+  | 'positive'
+  | 'neutral'
+  | 'deflect'
+  | 'pushback'
+  | 'suspicious'
+  | 'curious';
 
 export interface ReactionSummary {
   take: ReactionTake;
@@ -84,7 +153,18 @@ export interface GameState {
   editPerception: EditPerception;
   alliances: Alliance[];
   votingHistory: VotingRecord[];
-  gamePhase: 'intro' | 'premiere' | 'daily' | 'player_vote' | 'elimination' | 'weekly_recap' | 'finale' | 'immunity_competition' | 'jury_vote' | 'final_3_vote' | 'post_season';
+  gamePhase:
+    | 'intro'
+    | 'premiere'
+    | 'daily'
+    | 'player_vote'
+    | 'elimination'
+    | 'weekly_recap'
+    | 'finale'
+    | 'immunity_competition'
+    | 'jury_vote'
+    | 'final_3_vote'
+    | 'post_season';
   twistsActivated: string[];
   nextEliminationDay: number;
   daysUntilJury?: number; // Days until jury phase starts
@@ -108,7 +188,12 @@ export interface GameState {
   finaleSpeech?: string; // Store player's finale speech for jury consideration
   aiSettings: AISettings; // Controls reply depth and additions
   // New: queue of NPC-initiated forced conversations (at least one per day)
-  forcedConversationsQueue?: { from: string; topic: string; urgency: 'casual' | 'important'; day: number }[];
+  forcedConversationsQueue?: {
+    from: string;
+    topic: string;
+    urgency: 'casual' | 'important';
+    day: number
+  }[];
   // New: running tally for America's Favorite Player signals (computed each week, surfaced at finale)
   favoriteTally?: { [name: string]: number };
   // New: local interaction log for viral moments and memory tab
@@ -116,7 +201,9 @@ export interface GameState {
   tagChoiceCooldowns?: { [key: string]: number };
   lastTagOutcome?: LastTagOutcome; // For debugging/verification of tag engine integration
   // Persistent Reaction Profiles (computed at start and updated incrementally)
-  reactionProfiles?: { [npcIdOrName: string]: import('./tagDialogue').ReactionProfile };
+  reactionProfiles?: {
+    [npcIdOrName: string]: import('./tagDialogue').ReactionProfile
+  };
   // Debug flag to surface dev-only UI
   debugMode?: boolean;
   // Post-game data
@@ -139,6 +226,14 @@ export interface GameState {
   // Viewer Ratings - light system based on house events and NPC behavior
   viewerRating?: number; // 0.0 - 10.0
   ratingsHistory?: { day: number; rating: number; reason?: string }[];
+
+  // Special twist state tracking
+  // Only one 'hosts_estranged_child' per season recommended.
+  hostChildName?: string;
+  productionTaskLog?: {
+    // For planted houseguest(s): centralized log for recap
+    [contestantName: string]: { id: string; description: string; dayAssigned: number; completed?: boolean }[];
+  };
 }
 
 export interface Confessional {
@@ -154,10 +249,29 @@ export interface Confessional {
 export interface EditPerception {
   screenTimeIndex: number; // 0 to 100
   audienceApproval: number; // -100 to 100
-  persona: 'Hero' | 'Villain' | 'Underedited' | 'Ghosted' | 'Comic Relief' | 'Dark Horse' | 
-           'Mastermind' | 'Puppet Master' | 'Strategic Player' | 'Antagonist' | 'Troublemaker' |
-           'Flirt' | 'Gossip' | 'Social Butterfly' | 'Floater' | 'Class Clown' | 'Seducer' |
-           'Romantic' | 'Fan Favorite' | 'Pariah' | 'Contender' | 'Controversial';
+  persona:
+    | 'Hero'
+    | 'Villain'
+    | 'Underedited'
+    | 'Ghosted'
+    | 'Comic Relief'
+    | 'Dark Horse'
+    | 'Mastermind'
+    | 'Puppet Master'
+    | 'Strategic Player'
+    | 'Antagonist'
+    | 'Troublemaker'
+    | 'Flirt'
+    | 'Gossip'
+    | 'Social Butterfly'
+    | 'Floater'
+    | 'Class Clown'
+    | 'Seducer'
+    | 'Romantic'
+    | 'Fan Favorite'
+    | 'Pariah'
+    | 'Contender'
+    | 'Controversial';
   lastEditShift: number;
   weeklyQuote?: string;
 }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -155,6 +155,7 @@ export interface GameState {
   votingHistory: VotingRecord[];
   gamePhase:
     | 'intro'
+    | 'character_creation'
     | 'premiere'
     | 'daily'
     | 'player_vote'

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -34,12 +34,14 @@ export type SpecialBackground =
       kind: 'hosts_estranged_child';
       // Hidden until revealed. If revealed, affects audience/edit and NPC trust.
       revealed?: boolean;
+      revealDay?: number;
     }
   | {
       kind: 'planted_houseguest';
       // Production tasks to complete weekly. Failure risks secret reveal.
       tasks: { id: string; description: string; dayAssigned: number; completed?: boolean }[];
       secretRevealed?: boolean;
+      revealDay?: number;
     };
 
 export interface Contestant {
@@ -157,6 +159,7 @@ export interface GameState {
     | 'intro'
     | 'character_creation'
     | 'premiere'
+    | 'houseguests_roster'
     | 'daily'
     | 'player_vote'
     | 'elimination'
@@ -227,6 +230,13 @@ export interface GameState {
   // Viewer Ratings - light system based on house events and NPC behavior
   viewerRating?: number; // 0.0 - 10.0
   ratingsHistory?: { day: number; rating: number; reason?: string }[];
+
+  // Special reveal metadata
+  hostChildName?: string;
+  hostChildRevealDay?: number;
+  productionTaskLog?: {
+    [contestantName: string]: { id: string; description: string; dayAssigned: number; completed?: boolean }[];
+  };
 
   // Special twist state tracking
   // Only one 'hosts_estranged_child' per season recommended.

--- a/src/utils/npcGeneration.ts
+++ b/src/utils/npcGeneration.ts
@@ -1,0 +1,102 @@
+import { Contestant, CharacterStats, Background, SpecialBackground } from '@/types/game';
+import { BACKGROUND_META, PRESET_BACKGROUNDS } from '@/data/backgrounds';
+
+const STATIC_NPC_NAMES = [
+  'Ava', 'Liam', 'Mia', 'Noah', 'Zoe', 'Ethan', 'Isla', 'Lucas', 'Ivy', 'Mason',
+  'Ruby', 'Logan', 'Nora', 'Elijah', 'Luna', 'James', 'Maya', 'Oliver', 'Hazel', 'Jack'
+];
+
+function baseStats(primary: keyof CharacterStats): CharacterStats {
+  const baseline = { social: 50, strategy: 50, physical: 50, deception: 50, primary };
+  const boost = 20;
+  return {
+    ...baseline,
+    [primary]: baseline[primary] + boost,
+  } as CharacterStats;
+}
+
+function biasFromBackground(bg: Background, stats: CharacterStats): CharacterStats {
+  const meta = BACKGROUND_META.find(m => m.name === bg);
+  if (!meta || !meta.statBias) return stats;
+  const next = { ...stats };
+  Object.entries(meta.statBias).forEach(([k, v]) => {
+    const key = k as keyof CharacterStats;
+    next[key] = Math.max(20, Math.min(95, (next[key] || 50) + (v || 0)));
+  });
+  return next;
+}
+
+function randomPersonaFromStats(stats: CharacterStats): string {
+  // Simple mapping to publicPersona
+  const { social, strategy, physical, deception } = stats;
+  const max = Math.max(social, strategy, physical, deception);
+  if (max === social) return 'Social Butterfly';
+  if (max === strategy) return 'Strategic Player';
+  if (max === physical) return 'Competitor';
+  return 'Wildcard';
+}
+
+export interface NPCGenOptions {
+  count: number;
+  excludeNames?: string[];
+  includeSpecials?: boolean;
+}
+
+export function generateStaticNPCs(opts: NPCGenOptions): Contestant[] {
+  const taken = new Set(opts.excludeNames || []);
+  const names = STATIC_NPC_NAMES.filter(n => !taken.has(n)).slice(0, opts.count);
+  const result: Contestant[] = [];
+
+  let hostChildAssigned = false;
+  let plantedAssigned = false;
+
+  names.forEach((name, idx) => {
+    const id = `npc_${name.toLowerCase()}`;
+    const age = 21 + Math.floor(Math.random() * 19);
+    const bg = PRESET_BACKGROUNDS[Math.floor(Math.random() * (PRESET_BACKGROUNDS.length - 1))] as Background; // avoid 'Other'
+    const primaryPool = ['social', 'strategy', 'physical', 'deception'] as const;
+    const primary = primaryPool[idx % primaryPool.length];
+
+    let stats = biasFromBackground(bg, baseStats(primary));
+    const publicPersona = randomPersonaFromStats(stats);
+
+    let special: SpecialBackground = { kind: 'none' };
+    if (opts.includeSpecials) {
+      if (!hostChildAssigned && Math.random() < 0.15) {
+        special = { kind: 'hosts_estranged_child', revealed: false };
+        hostChildAssigned = true;
+      } else if (!plantedAssigned && Math.random() < 0.2) {
+        special = {
+          kind: 'planted_houseguest',
+          tasks: [
+            { id: 't1', description: 'Start a rumor about the immunity twist', dayAssigned: 3 },
+            { id: 't2', description: 'Convince two players to target each other', dayAssigned: 6 },
+          ],
+          secretRevealed: false,
+        };
+        plantedAssigned = true;
+      }
+    }
+
+    result.push({
+      id,
+      name,
+      age,
+      background: bg,
+      stats,
+      special,
+      publicPersona,
+      psychProfile: {
+        disposition: ['neutral'],
+        trustLevel: Math.floor(Math.random() * 40) + 30,
+        suspicionLevel: Math.floor(Math.random() * 40) + 20,
+        emotionalCloseness: Math.floor(Math.random() * 40) + 20,
+        editBias: 0,
+      },
+      memory: [],
+      isEliminated: false,
+    });
+  });
+
+  return result;
+}

--- a/src/utils/specialBackgrounds.ts
+++ b/src/utils/specialBackgrounds.ts
@@ -1,0 +1,81 @@
+import { GameState, Contestant } from '@/types/game';
+
+// Lightweight helpers to handle special backgrounds effects.
+// These functions are deterministic per call and should be invoked by the game loop once per day or at key events.
+
+function findContestant(gs: GameState, name: string): Contestant | undefined {
+  return gs.contestants.find(c => c.name === name);
+}
+
+export function applyDailySpecialBackgroundLogic(gs: GameState): GameState {
+  const next = { ...gs, contestants: gs.contestants.map(c => ({ ...c })) };
+
+  next.contestants.forEach(c => {
+    if (!c.special || c.special.kind === 'none') return;
+
+    if (c.special.kind === 'hosts_estranged_child') {
+      // If revealed, slight persistent edit bias, mixed trust changes
+      if (c.special.revealed) {
+        c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 2);
+        // Strategic players may distrust a bit; empathetic may increase closeness.
+        c.psychProfile.trustLevel = Math.max(-100, c.psychProfile.trustLevel - 1);
+      }
+    }
+
+    if (c.special.kind === 'planted_houseguest') {
+      // If any overdue incomplete task from 2+ days ago, chance to auto-reveal
+      const overdue = c.special.tasks.filter(t => !t.completed && t.dayAssigned <= (gs.currentDay - 2));
+      if (overdue.length >= 2 && !c.special.secretRevealed) {
+        c.special.secretRevealed = true;
+        // On reveal, suspicion spikes for some in the house
+        c.psychProfile.suspicionLevel = Math.min(100, c.psychProfile.suspicionLevel + 15);
+        // Centralize in production log for recaps
+        next.productionTaskLog = next.productionTaskLog || {};
+        next.productionTaskLog[c.name] = [...(next.productionTaskLog[c.name] || []), ...overdue];
+      }
+    }
+  });
+
+  return next;
+}
+
+// Call when the player completes or fails a production task.
+export function setProductionTaskStatus(gs: GameState, contestantName: string, taskId: string, completed: boolean): GameState {
+  const next = { ...gs, contestants: gs.contestants.map(c => ({ ...c })) };
+  const c = next.contestants.find(x => x.name === contestantName);
+  if (!c?.special || c.special.kind !== 'planted_houseguest') return next;
+
+  const task = c.special.tasks.find(t => t.id === taskId);
+  if (task) task.completed = completed;
+
+  // Reward success with slight editBias and influence (modeled via trust)
+  if (completed) {
+    c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 3);
+    c.psychProfile.trustLevel = Math.min(100, c.psychProfile.trustLevel + 2);
+  } else {
+    c.psychProfile.suspicionLevel = Math.min(100, c.psychProfile.suspicionLevel + 4);
+  }
+
+  next.productionTaskLog = next.productionTaskLog || {};
+  next.productionTaskLog[contestantName] = next.productionTaskLog[contestantName] || [];
+  const existing = next.productionTaskLog[contestantName].find(t => t.id === taskId);
+  if (!existing && task) {
+    next.productionTaskLog[contestantName].push({ ...task });
+  }
+
+  return next;
+}
+
+// Helper to reveal host child twist intentionally (e.g., via event)
+export function revealHostChild(gs: GameState, contestantName: string): GameState {
+  const next = { ...gs, contestants: gs.contestants.map(c => ({ ...c })) };
+  const c = next.contestants.find(x => x.name === contestantName);
+  if (c?.special && c.special.kind === 'hosts_estranged_child') {
+    c.special.revealed = true;
+    next.hostChildName = c.name;
+    // Mixed reaction buff/nerf
+    c.psychProfile.trustLevel = Math.max(-100, c.psychProfile.trustLevel - 5);
+    c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 10);
+  }
+  return next;
+}

--- a/src/utils/specialBackgrounds.ts
+++ b/src/utils/specialBackgrounds.ts
@@ -19,6 +19,11 @@ export function applyDailySpecialBackgroundLogic(gs: GameState): GameState {
         c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 2);
         // Strategic players may distrust a bit; empathetic may increase closeness.
         c.psychProfile.trustLevel = Math.max(-100, c.psychProfile.trustLevel - 1);
+        if (!c.special.revealDay) {
+          c.special.revealDay = gs.currentDay;
+          next.hostChildName = c.name;
+          next.hostChildRevealDay = gs.currentDay;
+        }
       }
     }
 
@@ -27,6 +32,7 @@ export function applyDailySpecialBackgroundLogic(gs: GameState): GameState {
       const overdue = c.special.tasks.filter(t => !t.completed && t.dayAssigned <= (gs.currentDay - 2));
       if (overdue.length >= 2 && !c.special.secretRevealed) {
         c.special.secretRevealed = true;
+        c.special.revealDay = gs.currentDay;
         // On reveal, suspicion spikes for some in the house
         c.psychProfile.suspicionLevel = Math.min(100, c.psychProfile.suspicionLevel + 15);
         // Centralize in production log for recaps
@@ -72,7 +78,9 @@ export function revealHostChild(gs: GameState, contestantName: string): GameStat
   const c = next.contestants.find(x => x.name === contestantName);
   if (c?.special && c.special.kind === 'hosts_estranged_child') {
     c.special.revealed = true;
+    c.special.revealDay = gs.currentDay;
     next.hostChildName = c.name;
+    next.hostChildRevealDay = gs.currentDay;
     // Mixed reaction buff/nerf
     c.psychProfile.trustLevel = Math.max(-100, c.psychProfile.trustLevel - 5);
     c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 10);


### PR DESCRIPTION
This PR addresses the issue of player votes being displayed as undefined in the finale screens. In `JuryVoteScreen.tsx`, the code now checks if the vote is present for each jury member and displays 'did not vote' or 'vote pending' accordingly for the current player. Similarly, in `PostSeasonRecapScreen.tsx`, it updates the vote display logic to show 'did not vote' or 'vote pending' instead of leaving it undefined. These changes improve clarity and user experience by ensuring players can always see the status of their vote.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/k3gqhhnodra7](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/k3gqhhnodra7)
Author: Evan Lewis
