### PR TITLE
Fix ReferenceError for generateStaticNPCs in Game State Hook

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { npcResponseEngine } from '@/utils/npcResponseEngine';
 import { GameState, PlayerAction, ReactionSummary, ReactionTake, Contestant } from '@/types/game';
 import { generateContestants } from '@/utils/contestantGenerator';
+import { generateStaticNPCs } from '@/utils/npcGeneration';
 import { calculateLegacyEditPerception } from '@/utils/editEngine';
 import { AllianceManager } from '@/utils/allianceManager';
 import { InformationTradingEngine } from '@/utils/informationTradingEngine';


### PR DESCRIPTION
This pull request resolves the ReferenceError encountered when starting the game related to the undefined function `generateStaticNPCs`. The function has been imported in the `useGameState` hook from the correct utility file, enabling NPC generation during character creation. This should allow the game to proceed without interruption.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/1bnygydbheg3](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/1bnygydbheg3)
Author: Evan Lewis
