### PR TITLE
Remove Special Backgrounds from NPCs During Generation

### DIFF
--- a/src/utils/npcGeneration.ts
+++ b/src/utils/npcGeneration.ts
@@ -39,16 +39,12 @@ function randomPersonaFromStats(stats: CharacterStats): string {
 export interface NPCGenOptions {
   count: number;
   excludeNames?: string[];
-  includeSpecials?: boolean;
 }
 
 export function generateStaticNPCs(opts: NPCGenOptions): Contestant[] {
   const taken = new Set(opts.excludeNames || []);
   const names = STATIC_NPC_NAMES.filter(n => !taken.has(n)).slice(0, opts.count);
   const result: Contestant[] = [];
-
-  let hostChildAssigned = false;
-  let plantedAssigned = false;
 
   names.forEach((name, idx) => {
     const id = `npc_${name.toLowerCase()}`;
@@ -57,26 +53,10 @@ export function generateStaticNPCs(opts: NPCGenOptions): Contestant[] {
     const primaryPool = ['social', 'strategy', 'physical', 'deception'] as const;
     const primary = primaryPool[idx % primaryPool.length];
 
-    let stats = biasFromBackground(bg, baseStats(primary));
+    const stats = biasFromBackground(bg, baseStats(primary));
     const publicPersona = randomPersonaFromStats(stats);
 
-    let special: SpecialBackground = { kind: 'none' };
-    if (opts.includeSpecials) {
-      if (!hostChildAssigned && Math.random() < 0.15) {
-        special = { kind: 'hosts_estranged_child', revealed: false };
-        hostChildAssigned = true;
-      } else if (!plantedAssigned && Math.random() < 0.2) {
-        special = {
-          kind: 'planted_houseguest',
-          tasks: [
-            { id: 't1', description: 'Start a rumor about the immunity twist', dayAssigned: 3 },
-            { id: 't2', description: 'Convince two players to target each other', dayAssigned: 6 },
-          ],
-          secretRevealed: false,
-        };
-        plantedAssigned = true;
-      }
-    }
+    const special: SpecialBackground = { kind: 'none' };
 
     result.push({
       id,

--- a/src/utils/specialBackgrounds.ts
+++ b/src/utils/specialBackgrounds.ts
@@ -7,35 +7,49 @@ function findContestant(gs: GameState, name: string): Contestant | undefined {
   return gs.contestants.find(c => c.name === name);
 }
 
-export function applyDailySpecialBackgroundLogic(gs: GameState): GameState {
+// Strip any special backgrounds from NPCs (non-player) to enforce rules.
+function sanitizeNPCSpecials(gs: GameState): GameState {
   const next = { ...gs, contestants: gs.contestants.map(c => ({ ...c })) };
+  next.contestants.forEach(c => {
+    if (c.name !== gs.playerName && c.special && c.special.kind !== 'none') {
+      c.special = { kind: 'none' };
+      if (next.hostChildName === c.name) {
+        next.hostChildName = undefined;
+        next.hostChildRevealDay = undefined;
+      }
+      if (next.productionTaskLog && next.productionTaskLog[c.name]) {
+        delete next.productionTaskLog[c.name];
+      }
+    }
+  });
+  return next;
+}
+
+export function applyDailySpecialBackgroundLogic(gs: GameState): GameState {
+  let next = sanitizeNPCSpecials(gs);
 
   next.contestants.forEach(c => {
+    if (c.name !== next.playerName) return;
     if (!c.special || c.special.kind === 'none') return;
 
     if (c.special.kind === 'hosts_estranged_child') {
-      // If revealed, slight persistent edit bias, mixed trust changes
       if (c.special.revealed) {
         c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 2);
-        // Strategic players may distrust a bit; empathetic may increase closeness.
         c.psychProfile.trustLevel = Math.max(-100, c.psychProfile.trustLevel - 1);
         if (!c.special.revealDay) {
-          c.special.revealDay = gs.currentDay;
+          c.special.revealDay = next.currentDay;
           next.hostChildName = c.name;
-          next.hostChildRevealDay = gs.currentDay;
+          next.hostChildRevealDay = next.currentDay;
         }
       }
     }
 
     if (c.special.kind === 'planted_houseguest') {
-      // If any overdue incomplete task from 2+ days ago, chance to auto-reveal
-      const overdue = c.special.tasks.filter(t => !t.completed && t.dayAssigned <= (gs.currentDay - 2));
+      const overdue = c.special.tasks.filter(t => !t.completed && t.dayAssigned <= (next.currentDay - 2));
       if (overdue.length >= 2 && !c.special.secretRevealed) {
         c.special.secretRevealed = true;
-        c.special.revealDay = gs.currentDay;
-        // On reveal, suspicion spikes for some in the house
+        c.special.revealDay = next.currentDay;
         c.psychProfile.suspicionLevel = Math.min(100, c.psychProfile.suspicionLevel + 15);
-        // Centralize in production log for recaps
         next.productionTaskLog = next.productionTaskLog || {};
         next.productionTaskLog[c.name] = [...(next.productionTaskLog[c.name] || []), ...overdue];
       }
@@ -47,14 +61,15 @@ export function applyDailySpecialBackgroundLogic(gs: GameState): GameState {
 
 // Call when the player completes or fails a production task.
 export function setProductionTaskStatus(gs: GameState, contestantName: string, taskId: string, completed: boolean): GameState {
-  const next = { ...gs, contestants: gs.contestants.map(c => ({ ...c })) };
+  let next = sanitizeNPCSpecials(gs);
+  if (contestantName !== next.playerName) return next;
+
   const c = next.contestants.find(x => x.name === contestantName);
   if (!c?.special || c.special.kind !== 'planted_houseguest') return next;
 
   const task = c.special.tasks.find(t => t.id === taskId);
   if (task) task.completed = completed;
 
-  // Reward success with slight editBias and influence (modeled via trust)
   if (completed) {
     c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 3);
     c.psychProfile.trustLevel = Math.min(100, c.psychProfile.trustLevel + 2);
@@ -74,14 +89,15 @@ export function setProductionTaskStatus(gs: GameState, contestantName: string, t
 
 // Helper to reveal host child twist intentionally (e.g., via event)
 export function revealHostChild(gs: GameState, contestantName: string): GameState {
-  const next = { ...gs, contestants: gs.contestants.map(c => ({ ...c })) };
+  let next = sanitizeNPCSpecials(gs);
+  if (contestantName !== next.playerName) return next;
+
   const c = next.contestants.find(x => x.name === contestantName);
   if (c?.special && c.special.kind === 'hosts_estranged_child') {
     c.special.revealed = true;
-    c.special.revealDay = gs.currentDay;
+    c.special.revealDay = next.currentDay;
     next.hostChildName = c.name;
-    next.hostChildRevealDay = gs.currentDay;
-    // Mixed reaction buff/nerf
+    next.hostChildRevealDay = next.currentDay;
     c.psychProfile.trustLevel = Math.max(-100, c.psychProfile.trustLevel - 5);
     c.psychProfile.editBias = Math.min(50, c.psychProfile.editBias + 10);
   }


### PR DESCRIPTION
This PR addresses the issue where NPCs were incorrectly receiving special backstory tags and goals, which should only be assigned to the user. The following changes were made:

1. In `npcGeneration.ts`, the code responsible for assigning special backgrounds to NPCs has been removed. This ensures that NPCs will no longer have the 'hosts_estranged_child' or 'planted_houseguest' special types assigned during their creation.

2. In `specialBackgrounds.ts`, a new function `sanitizeNPCSpecials` has been implemented to strip any special backgrounds from non-player contestants. This function is invoked whenever special background logic is applied, ensuring that any solidified special backgrounds for NPCs are reset to 'none'.

These changes collectively ensure that NPCs are not assigned any special backgrounds, which resolves the reported issue.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/pbehudrqd17y](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/pbehudrqd17y)
Author: Evan Lewis
