### PR TITLE
Fix preview build issue by guarding localStorage usage

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -8,10 +8,20 @@ const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiO
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
+// In non-browser environments (SSR/build), window.localStorage is not available.
+// Guard its usage so the bundle can build successfully.
+const authOptions =
+  typeof window !== 'undefined'
+    ? {
+        storage: window.localStorage,
+        persistSession: true,
+        autoRefreshToken: true,
+      }
+    : {
+        persistSession: true,
+        autoRefreshToken: true,
+      };
+
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
-  auth: {
-    storage: localStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-  }
+  auth: authOptions,
 });


### PR DESCRIPTION
This pull request addresses the issue of the application being broken due to the use of `window.localStorage` directly in the supabase client configuration. In non-browser environments (like SSR or during builds), `localStorage` is unavailable, causing the preview to fail. 

To resolve this, I have modified the `src/integrations/supabase/client.ts` file to include a guard around the `localStorage` usage. Now, during server-side rendering or build processes, the application will safely skip using `localStorage`, allowing the bundle to build successfully. 

This should fix the build process and allow the preview to be successfully generated.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/x2ube6xv13l1](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/x2ube6xv13l1)
Author: Evan Lewis
