### PR TITLE
Implement Truth Vote Mechanism

### DIFF
--- a/src/components/game/GameplayScreen.tsx
+++ b/src/components/game/GameplayScreen.tsx
@@ -12,6 +12,7 @@ import { AllianceIntelligencePanel } from './AllianceIntelligencePanel';
 import { AIOutcomeDebug } from './AIOutcomeDebug';
 import { RatingsPanel } from './RatingsPanel';
 import { BasicConversationEngine } from './BasicConversationEngine';
+import { TruthVoteRequestPanel } from './TruthVoteRequestPanel';
 
 interface GameplayScreenProps {
   gameState: GameState;
@@ -65,6 +66,8 @@ export const GameplayScreen = ({ gameState, onUseAction, onAdvanceDay, onEmergen
                  selectedAlliance={gameState.alliances[0]?.id}
                />
              )}
+             {/* Ask for Truth Vote (per-person) */}
+             <TruthVoteRequestPanel gameState={gameState} />
              {/* Basic RPG-style conversation (lightweight set options) */}
              <BasicConversationEngine
                gameState={gameState}

--- a/src/components/game/TruthVoteCard.tsx
+++ b/src/components/game/TruthVoteCard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle, XCircle, HelpCircle } from 'lucide-react';
+
+type TruthVoteValue = 'truth' | 'lie' | 'maybe';
+
+interface TruthVoteCardProps {
+  voterName: string;
+  vote: TruthVoteValue;
+  statement: string;
+  rationale?: string;
+}
+
+const VoteIcon: React.FC<{ vote: TruthVoteValue }> = ({ vote }) => {
+  if (vote === 'truth') return <CheckCircle className="w-5 h-5 text-green-600" />;
+  if (vote === 'lie') return <XCircle className="w-5 h-5 text-red-600" />;
+  return <HelpCircle className="w-5 h-5 text-yellow-600" />;
+};
+
+const voteLabel = (vote: TruthVoteValue) => {
+  if (vote === 'truth') return 'Truth';
+  if (vote === 'lie') return 'Lie';
+  return 'Maybe';
+};
+
+const voteColorClass = (vote: TruthVoteValue) => {
+  if (vote === 'truth') return 'text-green-700';
+  if (vote === 'lie') return 'text-red-700';
+  return 'text-yellow-700';
+};
+
+export const TruthVoteCard: React.FC<TruthVoteCardProps> = ({ voterName, vote, statement, rationale }) => {
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="uppercase text-[10px]">Truth Vote</Badge>
+          <span className="text-sm text-muted-foreground">by {voterName}</span>
+        </div>
+        <VoteIcon vote={vote} />
+      </div>
+
+      <div className="mb-3">
+        <div className="text-xs text-muted-foreground">Statement</div>
+        <div className="text-sm text-foreground line-clamp-2">“{statement}”</div>
+      </div>
+
+      <div className={`text-sm font-medium ${voteColorClass(vote)} mb-2`}>
+        {voterName} votes: {voteLabel(vote)}
+      </div>
+
+      {rationale && (
+        <div className="text-xs text-muted-foreground">
+          {rationale}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/src/components/game/TruthVoteRequestPanel.tsx
+++ b/src/components/game/TruthVoteRequestPanel.tsx
@@ -1,0 +1,101 @@
+import React, { useMemo, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/enhanced-button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { GameState, Contestant } from '@/types/game';
+import { TruthVoteCard } from './TruthVoteCard';
+import { getTruthVote } from '@/utils/truthVoteEngine';
+
+interface TruthVoteRequestPanelProps {
+  gameState: GameState;
+}
+
+export const TruthVoteRequestPanel: React.FC<TruthVoteRequestPanelProps> = ({ gameState }) => {
+  const [selectedTarget, setSelectedTarget] = useState<string>('');
+  const [statement, setStatement] = useState('');
+  const [result, setResult] = useState<{ name: string; vote: 'truth' | 'lie' | 'maybe'; rationale?: string } | null>(null);
+
+  const availableTargets = useMemo(
+    () => gameState.contestants.filter(c => !c.isEliminated && c.name !== gameState.playerName),
+    [gameState.contestants, gameState.playerName]
+  );
+
+  const targetNPC: Contestant | undefined = useMemo(
+    () => gameState.contestants.find(c => c.name === selectedTarget),
+    [gameState.contestants, selectedTarget]
+  );
+
+  const canRequest = selectedTarget && statement.trim().length >= 8;
+
+  const handleRequestVote = () => {
+    if (!targetNPC) return;
+    const { vote, rationale } = getTruthVote(targetNPC, statement, gameState);
+    setResult({ name: targetNPC.name, vote, rationale });
+  };
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <h3 className="font-medium">Ask for a Truth Vote</h3>
+        <Badge variant="outline" className="text-[10px] ml-auto">No meta gaming</Badge>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Ask a specific houseguest to vote whether a statement is truth, lie, or maybe. This is their read—not omniscient knowledge.
+      </p>
+
+      <div className="grid grid-cols-1 gap-3">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Select Person</label>
+          <Select value={selectedTarget} onValueChange={setSelectedTarget}>
+            <SelectTrigger>
+              <SelectValue placeholder="Choose a houseguest..." />
+            </SelectTrigger>
+            <SelectContent className="z-50 bg-popover text-popover-foreground">
+              {availableTargets.map((contestant) => (
+                <SelectItem key={contestant.id} value={contestant.name}>
+                  {contestant.name} - {contestant.publicPersona}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Statement</label>
+          <Textarea
+            value={statement}
+            onChange={(e) => setStatement(e.target.value)}
+            placeholder="Write the claim you want them to judge (e.g., 'I didn't leak the plan')"
+            className="min-h-[88px]"
+          />
+          <div className="text-[11px] text-muted-foreground">
+            Tip: Keep it specific. Avoid revealing others’ private info in public.
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={() => { setSelectedTarget(''); setStatement(''); setResult(null); }} className="flex-1">
+          Reset
+        </Button>
+        <Button variant="action" onClick={handleRequestVote} disabled={!canRequest} className="flex-1">
+          Ask for Vote
+        </Button>
+      </div>
+
+      {result && (
+        <ScrollArea className="max-h-64">
+          <TruthVoteCard
+            voterName={result.name}
+            vote={result.vote}
+            statement={statement}
+            rationale={result.rationale}
+          />
+        </ScrollArea>
+      )}
+    </Card>
+  );
+};

--- a/src/utils/truthVoteEngine.ts
+++ b/src/utils/truthVoteEngine.ts
@@ -1,0 +1,63 @@
+import { Contestant, GameState } from '@/types/game';
+
+/**
+ * Lightweight heuristic: NPC casts a vote on whether a statement is true.
+ * "No meta gaming" — the read is based on their trust/suspicion and simple topic cues,
+ * not omniscient knowledge.
+ */
+export type TruthVoteValue = 'truth' | 'lie' | 'maybe';
+
+export interface TruthVoteResult {
+  vote: TruthVoteValue;
+  rationale: string;
+}
+
+const topicWeights = [
+  { key: /vote|eliminate|target|numbers/i, bias: -8 },        // game talk is often slippery
+  { key: /alliance|ally|secret/i, bias: -5 },                 // secrecy induces doubt
+  { key: /romance|flirt|relationship/i, bias: -3 },           // emotions cloud reads
+  { key: /confessional|truth is/i, bias: +4 },                // direct honesty signals
+  { key: /plan|strategy|scheme/i, bias: -4 },                 // strategic framing = spin
+  { key: /personal|history|fear|motivation/i, bias: +2 },     // personal vulnerability = sincerity
+];
+
+export function getTruthVote(npc: Contestant, statement: string, gameState: GameState): TruthVoteResult {
+  // Base read from NPC's current profile
+  const trust = npc.psychProfile.trustLevel;        // -100..100
+  const suspicion = npc.psychProfile.suspicionLevel; // 0..100
+
+  // Normalize to a simple score
+  let score = Math.round(trust / 2) - Math.round(suspicion / 3);
+
+  // Apply topic cues
+  for (const t of topicWeights) {
+    if (t.key.test(statement)) {
+      score += t.bias;
+    }
+  }
+
+  // Very light social context: if player and NPC are in an alliance, increase trust weighting slightly
+  const playerName = gameState.playerName;
+  const sameAlliance = gameState.alliances.some(a => !a.dissolved && a.members.includes(playerName) && a.members.includes(npc.name));
+  if (sameAlliance) {
+    score += 6;
+  }
+
+  // Recent memory: if NPC has a positive memory involving the player, slightly nudge toward truth
+  const recentMemories = npc.memory.filter(m => m.day >= gameState.currentDay - 3);
+  const positiveRecent = recentMemories.some(m => (m.participants || []).includes(playerName) && (m.emotionalImpact ?? 0) > 0);
+  if (positiveRecent) {
+    score += 5;
+  }
+
+  // Clamp and map to categorical vote
+  const clamped = Math.max(-100, Math.min(100, score));
+  let vote: TruthVoteValue;
+  if (clamped >= 25) vote = 'truth';
+  else if (clamped <= -10) vote = 'lie';
+  else vote = 'maybe';
+
+  const rationale = `Read based on current trust (${trust}), suspicion (${suspicion}), and context cues.`;
+
+  return { vote, rationale };
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows players to request votes on statements from specific houseguests within the game. The functionality is encapsulated in the `TruthVoteRequestPanel`, where players can select a contestant and submit a statement for judgment as either 'truth', 'lie', or 'maybe'. Upon submission, votes are computed based on the contestants' trust and suspicion levels, along with other contextual cues, and the results are displayed using the `TruthVoteCard`. This update enhances gameplay by providing a way to engage players in decision-making without meta-gaming.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/hjwuzazy3wg7](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/hjwuzazy3wg7)
Author: Evan Lewis
