### PR TITLE
Fix ReferenceError for onHouseMeetingChoice variable

### DIFF
--- a/src/components/game/ActionPanel.tsx
+++ b/src/components/game/ActionPanel.tsx
@@ -30,7 +30,7 @@ interface ActionPanelProps {
   onEndHouseMeeting: () => void;
 }
 
-export const ActionPanel = ({ gameState, onUseAction, onAdvanceDay, onEmergentEventChoice, onForcedConversationReply, onTagTalk, onAllianceMeeting }: ActionPanelProps) => {
+export const ActionPanel = ({ gameState, onUseAction, onAdvanceDay, onEmergentEventChoice, onForcedConversationReply, onTagTalk, onAllianceMeeting, onHouseMeetingChoice, onEndHouseMeeting }: ActionPanelProps) => {
   const [activeDialog, setActiveDialog] = useState<string | null>(null);
   const [showSkipDialog, setShowSkipDialog] = useState(false);
   const [forcedOpen, setForcedOpen] = useState(false);

--- a/src/components/game/GameplayScreen.tsx
+++ b/src/components/game/GameplayScreen.tsx
@@ -25,7 +25,7 @@ interface GameplayScreenProps {
   onEndHouseMeeting: () => void;
 }
 
-export const GameplayScreen = ({ gameState, onUseAction, onAdvanceDay, onEmergentEventChoice, onForcedConversationReply, onTagTalk }: GameplayScreenProps) => {
+export const GameplayScreen = ({ gameState, onUseAction, onAdvanceDay, onEmergentEventChoice, onForcedConversationReply, onTagTalk, onHouseMeetingChoice, onEndHouseMeeting }: GameplayScreenProps) => {
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-6 py-8 space-y-8">

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -2019,6 +2019,8 @@ export const useGameState = () => {
     resetGame,
     handleEmergentEventChoice,
     tagTalk,
+    handleHouseMeetingChoice,
+    endHouseMeeting,
     handleTieBreakResult,
     proceedToJuryVote,
     // New debug/test helpers


### PR DESCRIPTION
This pull request resolves a ReferenceError encountered during rendering, specifically 'Can't find variable: onHouseMeetingChoice'. The issue arose because the `onHouseMeetingChoice` prop was not being passed to the `ActionPanel` and `GameplayScreen` components. The changes include adding `onHouseMeetingChoice` and `onEndHouseMeeting` as props to both components in `ActionPanel.tsx` and `GameplayScreen.tsx`. Additionally, I've modified the `useGameState` hook to include `handleHouseMeetingChoice` and `endHouseMeeting` to ensure functionality related to house meetings is supported.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/0c1v3kmxzo7p](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/0c1v3kmxzo7p)
Author: Evan Lewis
