### PR TITLE
Enhance Scripted Story Beats for Host's Child and Planted Houseguest Arcs

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -191,11 +191,22 @@ export interface TwistNarrative {
 /**
  * Lightweight cutscene slide for story beats.
  */
+export interface CutsceneChoice {
+  id: string;
+  text: string;
+  televised?: boolean; // If true, choosing this affects edit perception lightly
+  editDelta?: number;  // Small +/- effect on edit (screenTime/approval) when televised
+}
+
 export interface CutsceneSlide {
   title?: string;
   speaker?: string;
   text: string;
   aside?: string;
+  // Optional simple branching for cutscenes
+  choices?: CutsceneChoice[];
+  // Slide context: if set, applies to all choices unless a choice overrides
+  televised?: boolean;
 }
 
 /**

--- a/src/utils/twistCutsceneBuilder.ts
+++ b/src/utils/twistCutsceneBuilder.ts
@@ -175,6 +175,26 @@ export function buildMidGameCutscene(gs: GameState, beat: NarrativeBeat) {
             },
           );
           break;
+        case 'hc_mars_private_meet':
+          slides.push(
+            {
+              title: 'Behind the Scenes',
+              speaker: 'Narrator',
+              text: 'A quiet hall, a closed door. Mars Vega doesn’t need cameras to read the room.',
+            },
+            {
+              title: 'Private: Mars Vega',
+              speaker: name,
+              text: 'We keep it professional. I set boundaries: my story isn’t a prop; my game is the show.',
+              aside: 'This meeting is off-camera. Choose the tone and move on.',
+              choices: [
+                { id: 'hc_private_keep_game', text: 'Keep it strictly game. “No favors.”', televised: false },
+                { id: 'hc_private_seek_grace', text: 'Ask for off-camera grace to control timing.', televised: false },
+              ],
+              televised: false,
+            },
+          );
+          break;
         case 'hc_consequence':
           slides.push(
             {
@@ -185,6 +205,26 @@ export function buildMidGameCutscene(gs: GameState, beat: NarrativeBeat) {
               title: 'Terms',
               speaker: name,
               text: 'No theatrics. I’ll make a clean week: direct talks, measurable follow-through. People remember consistency.',
+            },
+          );
+          break;
+        case 'hc_mars_televised_checkin':
+          slides.push(
+            {
+              title: 'Broadcast',
+              speaker: 'Narrator',
+              text: 'The red light blinks on. A check-in with Mars Vega turns a story into a segment.',
+            },
+            {
+              title: 'On-Camera: Mars Vega',
+              speaker: name,
+              text: 'I set the frame myself before anyone else does.',
+              aside: 'Televised choice — a light edit impact applies.',
+              choices: [
+                { id: 'hc_tv_own', text: 'Own it cleanly. Set terms and move forward.', televised: true, editDelta: 4 },
+                { id: 'hc_tv_deflect', text: 'Deflect to strategy. Minimize the headline.', televised: true, editDelta: -2 },
+              ],
+              televised: true,
             },
           );
           break;
@@ -276,6 +316,26 @@ export function buildMidGameCutscene(gs: GameState, beat: NarrativeBeat) {
             },
           );
           break;
+        case 'phg_producer_brief':
+          slides.push(
+            {
+              title: 'Behind the Scenes',
+              speaker: 'Narrator',
+              text: 'A producer checks your cover integrity. Notes are given in whispers, not scripts.',
+            },
+            {
+              title: 'Producer Brief',
+              speaker: name,
+              text: 'Guardrails are fine; I need room to improvise without breaking character.',
+              aside: 'Off-camera. Choose how tightly you want to play it.',
+              choices: [
+                { id: 'phg_guardrails_tight', text: 'Accept tighter guardrails. Fewer flashy moves.', televised: false },
+                { id: 'phg_guardrails_loose', text: 'Ask for leeway to pivot mid-conversation.', televised: false },
+              ],
+              televised: false,
+            },
+          );
+          break;
         case 'phg_cover_story':
           slides.push(
             {
@@ -288,6 +348,62 @@ export function buildMidGameCutscene(gs: GameState, beat: NarrativeBeat) {
               text: back.line
                 ? `${back.line} That’s the spine. Every conversation bends to that shape.`
                 : 'I’ll pick a simple identity and never deviate on camera.',
+            },
+          );
+          break;
+        case 'phg_risky_plant':
+          slides.push(
+            {
+              title: 'The Plant',
+              speaker: 'Narrator',
+              text: 'Risk is the premium paid for influence. You place a seed and pretend you forgot you did. The house waters it for you.',
+            },
+            {
+              title: 'Execution',
+              speaker: name,
+              text: 'Casual tone. Specific detail. Someone repeats it. Now it lives. If it traces back, it still sounds like me.',
+            },
+            {
+              title: 'Cover Integrity',
+              text: back.line
+                ? `Your cover loops through your ${player?.background?.toLowerCase() || 'day-one'} habits. Repetition protects you.`
+                : 'Define a habit, a phrase, a daily rhythm—make it your alibi.',
+            },
+          );
+          break;
+        case 'phg_close_call':
+          slides.push(
+            {
+              title: 'Close Call',
+              text: 'Eyes linger too long. Your alibi needs a second draft. You slow your pulse and speed up your context.',
+              aside: 'Consistency beats brilliance. Repeat the cover.',
+            },
+            {
+              title: 'Reframe',
+              speaker: name,
+              text: back.line
+                ? `Lean into ${player?.background?.toLowerCase()}: give a reason only that persona would give.`
+                : 'Offer a reason only your established persona would offer.',
+            },
+          );
+          break;
+        case 'phg_mars_televised_checkin':
+          slides.push(
+            {
+              title: 'Broadcast',
+              speaker: 'Narrator',
+              text: 'Mars Vega leads a quick check-in. The camera looks for a wink; the audience looks for a tell.',
+            },
+            {
+              title: 'On-Camera: Mars Vega',
+              speaker: name,
+              text: 'I can be legible without being obvious.',
+              aside: 'Televised choice — a light edit impact applies.',
+              choices: [
+                { id: 'phg_tv_wink', text: 'Give a playful line that keeps the cover intact.', televised: true, editDelta: 3 },
+                { id: 'phg_tv_straight', text: 'Play it straight and low-key.', televised: true, editDelta: 1 },
+              ],
+              televised: true,
             },
           );
           break;

--- a/src/utils/twistNarrativeEngine.ts
+++ b/src/utils/twistNarrativeEngine.ts
@@ -20,8 +20,10 @@ function buildHostChildBeats(startDay: number): NarrativeBeat[] {
   return [
     { id: 'hc_premiere_seeds', title: 'Premiere Seeds', dayPlanned: startDay, status: 'planned' },
     { id: 'hc_rumor_swirl', title: 'Rumor Swirl', dayPlanned: startDay + 3, status: 'planned' },
+    { id: 'hc_mars_private_meet', title: 'Private: Mars Vega', dayPlanned: startDay + 8, status: 'planned' },
     { id: 'hc_reveal', title: 'Reveal', dayPlanned: startDay + 10, status: 'planned' },
     { id: 'hc_consequence', title: 'Consequences', dayPlanned: startDay + 11, status: 'planned' },
+    { id: 'hc_mars_televised_checkin', title: 'Televised Check-In: Mars Vega', dayPlanned: startDay + 14, status: 'planned' },
     { id: 'hc_redemption_attempt', title: 'Redemption Attempt', dayPlanned: startDay + 21, status: 'planned' },
     { id: 'hc_final_reckoning', title: 'Final Reckoning', dayPlanned: startDay + 28, status: 'planned' },
   ];
@@ -30,9 +32,11 @@ function buildHostChildBeats(startDay: number): NarrativeBeat[] {
 function buildPlantedHGBeats(startDay: number): NarrativeBeat[] {
   return [
     { id: 'phg_mission_brief', title: 'Mission Brief', dayPlanned: startDay + 2, status: 'planned' },
+    { id: 'phg_producer_brief', title: 'Behind the Scenes: Producer Brief', dayPlanned: startDay + 3, status: 'planned' },
     { id: 'phg_cover_story', title: 'Cover Story Built', dayPlanned: startDay + 5, status: 'planned' },
     { id: 'phg_risky_plant', title: 'Risky Plant Executed', dayPlanned: startDay + 9, status: 'planned' },
     { id: 'phg_close_call', title: 'Close Call', dayPlanned: startDay + 13, status: 'planned' },
+    { id: 'phg_mars_televised_checkin', title: 'Televised Check-In: Mars Vega', dayPlanned: startDay + 15, status: 'planned' },
     { id: 'phg_double_down', title: 'Double-Down Mission', dayPlanned: startDay + 17, status: 'planned' },
     { id: 'phg_exposure_test', title: 'Exposure Test', dayPlanned: startDay + 21, status: 'planned' },
     { id: 'phg_endgame_leverage', title: 'Endgame Leverage', dayPlanned: startDay + 26, status: 'planned' },


### PR DESCRIPTION
This pull request introduces unique and deterministic story beats specifically for the Host's estranged child twist and the Planted Houseguest twist. The changes replace generic narrative lines with crafted, consistent dialogues that trigger based on selected beats, ensuring depth and a coherent storyline across all playthroughs. Each arc now has tailored cutscenes that reflect the character's journey and emotional stakes, thereby improving narrative quality and engagement. Fallback content is included in case of any unexpected beats, but the intention is for all gameplay to feel impactful and narrative-driven.

---

> This pull request was co-created with Cosine Genie

Original Task: [the-edit-beta/vtkk8awz5zml](https://cosine.sh/w45mw06ms2s7/the-edit-beta/task/vtkk8awz5zml)
Author: Evan Lewis
